### PR TITLE
README: fix bcat link to github.io & add https

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $ gem install twdeps
   task export | twdeps --format svg | bcat
   ```
 
-  [bcat](http://rtomayko.github.com/bcat/) is required for piping into a browser.
+  [bcat](https://rtomayko.github.io/bcat/) is required for piping into a browser.
 
 ## Dependencies
 


### PR DESCRIPTION
current link to https://rtomayko.github.com/bcat/ is broken and https://rtomayko.github.io/bcat/ seems to be the correct link instead

by that change, also changed that link from http:// to https://